### PR TITLE
Requirements structure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+zope.interface
 Flask
 docopt
 GitPython

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,3 @@
+-r requirements.txt
 nose
 mock


### PR DESCRIPTION
A missing requirement, plus a neat trick I learned today.

With this structure you do not need to pip install multiple files. If you want to test, just:
`pip install -r test-requirements.txt`.
