### PR TITLE
Fix failing tests, rename function and other cleanup

### DIFF
--- a/deploystream/__init__.py
+++ b/deploystream/__init__.py
@@ -1,4 +1,5 @@
-VERSION = '0.1'
+__version__ = '0.1'
+
 from os import environ
 from os.path import join, dirname
 from flask import Flask
@@ -17,4 +18,4 @@ from providers import init_plugins
 init_plugins()
 
 # Import any views we want to register here at the bottom of the file:
-import deploystream.apps.feature.views
+import deploystream.apps.feature.views  # NOQA

--- a/deploystream/apps/feature/lib.py
+++ b/deploystream/apps/feature/lib.py
@@ -11,8 +11,8 @@ def get_feature_info(feature_id):
     # First get any feature info from any management providers
     for plugin in PLANNING_PLUGINS:
         feature.planning_info = PlanningInfo(
-                                plugin=plugin,
-                                **plugin.get_feature_info(feature_id))
+            plugin=plugin,
+            **plugin.get_feature_info(feature_id))
 
     # Then get any branch info from any source control providers
     for plugin in SOURCE_CODE_PLUGINS:
@@ -32,9 +32,9 @@ def get_feature_info(feature_id):
     for plugin in BUILD_INFO_PLUGINS:
         for branch in feature.branches:
             branch.build_info = BuildInfo(plugin=plugin,
-                                       **plugin.get_build_information(
-                                                    branch.repo_name,
-                                                    branch.branch_name,
-                                                    branch.latest_commit)
-                                       )
+                                          **plugin.get_build_information(
+                                              branch.repo_name,
+                                              branch.branch_name,
+                                              branch.latest_commit)
+                                          )
     return feature

--- a/deploystream/providers/__init__.py
+++ b/deploystream/providers/__init__.py
@@ -4,7 +4,7 @@ from importlib import import_module
 
 from interfaces import (
     ISourceCodeControlPlugin, IBuildInfoPlugin, IPlanningPlugin,
-    isimplementation
+    is_implementation
 )
 
 PLANNING_PLUGINS = []
@@ -31,7 +31,7 @@ def init_plugin_set(plugin_set, plugin_interface, plugin_holder):
     "Create a set of plugins, check they are correct, add to a placeholder"
     for path in plugin_set:
         plugin_class = get_plugin_class(path)
-        if isimplementation(plugin_class, plugin_interface):
+        if is_implementation(plugin_class, plugin_interface):
             plugin_holder.append(plugin_class())
 
 

--- a/deploystream/providers/__init__.py
+++ b/deploystream/providers/__init__.py
@@ -4,7 +4,8 @@ from importlib import import_module
 
 from interfaces import (
     ISourceCodeControlPlugin, IBuildInfoPlugin, IPlanningPlugin,
-    check_class_implements_interface)
+    isimplementation
+)
 
 PLANNING_PLUGINS = []
 SOURCE_CODE_PLUGINS = []
@@ -30,12 +31,11 @@ def init_plugin_set(plugin_set, plugin_interface, plugin_holder):
     "Create a set of plugins, check they are correct, add to a placeholder"
     for path in plugin_set:
         plugin_class = get_plugin_class(path)
-        if check_class_implements_interface(plugin_class, plugin_interface):
+        if isimplementation(plugin_class, plugin_interface):
             plugin_holder.append(plugin_class())
 
 
 def init_plugins():
-    global PLUGINS
     from deploystream import app
     for config_name, plugin_class, holder in PLUGIN_INTERFACES:
         init_plugin_set(app.config[config_name],

--- a/deploystream/providers/git_plugin/plugin.py
+++ b/deploystream/providers/git_plugin/plugin.py
@@ -20,7 +20,7 @@ class GitPlugin(object):
                 1: branch name
                 2: latest commit
         """
-        pass
+        return []  # no info available for now
 
     def get_branches_involved(self, repo_location, feature_id):
         """
@@ -38,8 +38,8 @@ class GitPlugin(object):
                 0: branch name
                 1: latest commit
         """
-        repo = git.Repo("{repo_location}/.git".format(
-                                                repo_location=repo_location))
+        repo = git.Repo("{repo_location}/.git"
+                        .format(repo_location=repo_location))
         remote = git.remote.Remote(repo, 'origin')
         affected = []
         for remote_ref in remote.refs:

--- a/deploystream/providers/interfaces/__init__.py
+++ b/deploystream/providers/interfaces/__init__.py
@@ -1,15 +1,24 @@
 from zope import interface as zinterface
+from zope.interface import verify
 
 from build_info import IBuildInfoPlugin
 from planning import IPlanningPlugin
 from source_code_control import ISourceCodeControlPlugin
 
 
-def check_class_implements_interface(cls, interface):
-    "Check that the given class implements the given interface. Return Bool"
+def isimplementation(cls, interface):
+    """
+    Check that the given class implements the given interface.
+
+    Mimics the signature and behaviour of `isinstance`, for interfaces.
+
+    :returns:
+        A boolean
+    """
     zinterface.classImplements(cls, interface)
     try:
         zinterface.verify.verifyClass(interface, cls)
         return True
     except Exception:
+        #raise
         return False

--- a/deploystream/providers/interfaces/__init__.py
+++ b/deploystream/providers/interfaces/__init__.py
@@ -1,9 +1,15 @@
 from zope import interface as zinterface
 from zope.interface import verify
 
+# These imports are here for convenience, to be re-imported by others
 from build_info import IBuildInfoPlugin
 from planning import IPlanningPlugin
 from source_code_control import ISourceCodeControlPlugin
+
+__all__ = [
+    IBuildInfoPlugin, IPlanningPlugin, ISourceCodeControlPlugin,
+    'isimplementation'
+]
 
 
 def isimplementation(cls, interface):
@@ -17,7 +23,7 @@ def isimplementation(cls, interface):
     """
     zinterface.classImplements(cls, interface)
     try:
-        zinterface.verify.verifyClass(interface, cls)
+        verify.verifyClass(interface, cls)
         return True
     except Exception:
         #raise

--- a/deploystream/providers/interfaces/__init__.py
+++ b/deploystream/providers/interfaces/__init__.py
@@ -8,11 +8,11 @@ from source_code_control import ISourceCodeControlPlugin
 
 __all__ = [
     IBuildInfoPlugin, IPlanningPlugin, ISourceCodeControlPlugin,
-    'isimplementation'
+    'is_implementation'
 ]
 
 
-def isimplementation(cls, interface):
+def is_implementation(cls, interface):
     """
     Check that the given class implements the given interface.
 

--- a/deploystream/runserver.py
+++ b/deploystream/runserver.py
@@ -1,4 +1,4 @@
-from deploystream import VERSION, app
+from deploystream import __version__, app
 
 USAGE = """
 deploystream {version}: runserver.py
@@ -17,11 +17,11 @@ Usage:
 Options:
     -h --help   Show this screen.
     --version   Show version.
-""".format(version=VERSION)
+""".format(version=__version__)
 
 if __name__ == '__main__':
     from docopt import docopt
-    arguments = docopt(USAGE, version=VERSION)
+    arguments = docopt(USAGE, version=__version__)
     kwargs = {}
     if arguments['<host_port>']:
         host, port = arguments['<host_port>'].split(':')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-zope.interface
-Flask
-docopt
-GitPython

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,0 +1,3 @@
+-r test.txt
+
+flake8           # combine pep8 and pyflakes (static analysis) in a single command

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,0 +1,5 @@
+docopt               # create command-line interface from docstring
+Flask                # web framework
+GitPython            # access git repositories
+jsonpickle           # encode/decode arbitrary objects to JSON
+zope.interface       # define and enforce interfaces

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,0 +1,4 @@
+-r runtime.txt
+
+nose                # test discovery and execution
+mock                # create mock objects and patch code for unit tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,0 @@
--r requirements.txt
-nose
-mock

--- a/tests/test_feature/test_view.py
+++ b/tests/test_feature/test_view.py
@@ -18,8 +18,9 @@ class PlanningPlugin(object):
             "title": "Amazing feature that will blow your mind",
             "id": feature_id,
             "url": "http://planning_site/{0}".format(feature_id),
-            "feature_type": "interesting",
-            "owner": "Bob"
+            "feature_type": "story",
+            "owner": "Bob",
+            "description": "Too good for words..."
         }
 
 
@@ -41,11 +42,11 @@ class TestEndToEndWithDummyPlugins(object):
         self.client = deploystream.app.test_client()
 
     @patch("deploystream.apps.feature.lib.PLANNING_PLUGINS",
-            [PlanningPlugin()])
+           [PlanningPlugin()])
     @patch("deploystream.apps.feature.lib.SOURCE_CODE_PLUGINS",
-            [SourceCodePlugin()])
+           [SourceCodePlugin()])
     @patch("deploystream.apps.feature.lib.BUILD_INFO_PLUGINS",
-            [BuildInfoPlugin()])
+           [BuildInfoPlugin()])
     def test_feature_view_shows_details(self):
         response = self.client.get('/feature/FT101')
         assert "Amazing feature that will blow your mind" in response.data

--- a/tests/test_providers/test_interfaces.py
+++ b/tests/test_providers/test_interfaces.py
@@ -1,8 +1,9 @@
 from nose.tools import assert_true, assert_false
 
 from deploystream.providers.interfaces import (
-    check_class_implements_interface, IBuildInfoPlugin, IPlanningPlugin,
-    ISourceCodeControlPlugin)
+    isimplementation,
+    IBuildInfoPlugin, IPlanningPlugin, ISourceCodeControlPlugin,
+)
 
 
 class TestSourceCodeControlPluginInterface(object):
@@ -14,8 +15,7 @@ class TestSourceCodeControlPluginInterface(object):
             def set_merged_status(self, repo_name, hierarchy_tree):
                 pass
 
-        assert_true(check_class_implements_interface(
-                            MyPlugin, ISourceCodeControlPlugin))
+        assert_true(isimplementation(MyPlugin, ISourceCodeControlPlugin))
 
     def test_does_not_implement_source_control_plugin(self):
         class MyPlugin(object):
@@ -24,8 +24,7 @@ class TestSourceCodeControlPluginInterface(object):
             def set_merged_status(self, repo_name):
                 pass
 
-        assert_false(check_class_implements_interface(
-                            MyPlugin, ISourceCodeControlPlugin))
+        assert_false(isimplementation(MyPlugin, ISourceCodeControlPlugin))
 
 
 class TestBuildInfoPluginInterface(object):
@@ -34,14 +33,14 @@ class TestBuildInfoPluginInterface(object):
         class MyPlugin(object):
             def get_build_information(self, repo, branch, commit):
                 pass
-        assert_true(check_class_implements_interface(
-                            MyPlugin, IBuildInfoPlugin))
+
+        assert_true(isimplementation(MyPlugin, IBuildInfoPlugin))
 
     def test_does_not_implement_build_info_plugin(self):
         class MyPlugin(object):
             pass
-        assert_false(check_class_implements_interface(
-                            MyPlugin, IBuildInfoPlugin))
+
+        assert_false(isimplementation(MyPlugin, IBuildInfoPlugin))
 
 
 class TestPlanningPluginInterface(object):
@@ -50,11 +49,11 @@ class TestPlanningPluginInterface(object):
         class MyPlugin(object):
             def get_feature_info(self, feature_id):
                 pass
-        assert_true(check_class_implements_interface(
-                            MyPlugin, IPlanningPlugin))
+
+        assert_true(isimplementation(MyPlugin, IPlanningPlugin))
 
     def test_does_not_implement_planning_plugin(self):
         class MyPlugin(object):
             pass
-        assert_false(check_class_implements_interface(
-                            MyPlugin, IPlanningPlugin))
+
+        assert_false(isimplementation(MyPlugin, IPlanningPlugin))

--- a/tests/test_providers/test_interfaces.py
+++ b/tests/test_providers/test_interfaces.py
@@ -1,7 +1,7 @@
 from nose.tools import assert_true, assert_false
 
 from deploystream.providers.interfaces import (
-    isimplementation,
+    is_implementation,
     IBuildInfoPlugin, IPlanningPlugin, ISourceCodeControlPlugin,
 )
 
@@ -15,7 +15,7 @@ class TestSourceCodeControlPluginInterface(object):
             def set_merged_status(self, repo_name, hierarchy_tree):
                 pass
 
-        assert_true(isimplementation(MyPlugin, ISourceCodeControlPlugin))
+        assert_true(is_implementation(MyPlugin, ISourceCodeControlPlugin))
 
     def test_does_not_implement_source_control_plugin(self):
         class MyPlugin(object):
@@ -24,7 +24,7 @@ class TestSourceCodeControlPluginInterface(object):
             def set_merged_status(self, repo_name):
                 pass
 
-        assert_false(isimplementation(MyPlugin, ISourceCodeControlPlugin))
+        assert_false(is_implementation(MyPlugin, ISourceCodeControlPlugin))
 
 
 class TestBuildInfoPluginInterface(object):
@@ -34,13 +34,13 @@ class TestBuildInfoPluginInterface(object):
             def get_build_information(self, repo, branch, commit):
                 pass
 
-        assert_true(isimplementation(MyPlugin, IBuildInfoPlugin))
+        assert_true(is_implementation(MyPlugin, IBuildInfoPlugin))
 
     def test_does_not_implement_build_info_plugin(self):
         class MyPlugin(object):
             pass
 
-        assert_false(isimplementation(MyPlugin, IBuildInfoPlugin))
+        assert_false(is_implementation(MyPlugin, IBuildInfoPlugin))
 
 
 class TestPlanningPluginInterface(object):
@@ -50,10 +50,10 @@ class TestPlanningPluginInterface(object):
             def get_feature_info(self, feature_id):
                 pass
 
-        assert_true(isimplementation(MyPlugin, IPlanningPlugin))
+        assert_true(is_implementation(MyPlugin, IPlanningPlugin))
 
     def test_does_not_implement_planning_plugin(self):
         class MyPlugin(object):
             pass
 
-        assert_false(isimplementation(MyPlugin, IPlanningPlugin))
+        assert_false(is_implementation(MyPlugin, IPlanningPlugin))


### PR DESCRIPTION
A number of small fixes:
- Fixes failing tests.
- Liberally renames a function :]
- Restructure requirements following a pattern from "Two scoops of Django" that I find quite neat
- Flake8 the project and clear errors
- Use `__version__` for version, which is the more standard Python metadata approach

After this, installing requirements will be a single line:

```
pip install -r requirements/<env>.txt
```

where `env` is either `runtime`, `test` or `ci` (for now)
