### PR TITLE
Make JS e2e tests pass again

### DIFF
--- a/deploystream/static/test/e2e/scenarios.js
+++ b/deploystream/static/test/e2e/scenarios.js
@@ -10,9 +10,11 @@ describe('my app', function () {
     });
 
 
-    it('should redirect to /features when location fragment is empty', function () {
-        browser().navigateTo('/');
-        expect(browser().location().url()).toBe("/features");
+    it('should show a login button when location fragment is empty', function () {
+        expect(browser().location().url()).toBe("/");
+        expect(element('a.btn-primary').text()).toContain('Sign in via Github');
+        //element('a.btn-primary').click();
+        //expect(browser().location().url()).toBe("/login");
     });
 
 });


### PR DESCRIPTION
I've changed the test slightly so that it passes now.

I'd like to get these tests back into shape by making them do something useful, but that will mean using `pretenders`. It will be simplest if it is hosted somewhere, that way we may be able to run these tests within Travis.
