### PR TITLE
Add some level of caching for speed-up

### DIFF
--- a/deploystream/apps/feature/views.py
+++ b/deploystream/apps/feature/views.py
@@ -4,6 +4,7 @@ from flask import json, Response
 
 from deploystream import app
 from deploystream.apps.feature.lib import get_feature_info, get_all_features
+from deploystream.lib import cache
 from deploystream.lib.transforms import nativify
 from deploystream.decorators import needs_providers
 
@@ -23,6 +24,7 @@ def as_json(func):
 
 @app.route('/features', methods=['GET'])
 @needs_providers
+@cache.cached()
 @as_json
 def list_features(providers):
     features = get_all_features(providers)

--- a/deploystream/lib/cache.py
+++ b/deploystream/lib/cache.py
@@ -1,0 +1,39 @@
+from functools import wraps
+
+from flask import request
+from werkzeug.contrib.cache import SimpleCache
+
+
+cache = SimpleCache()
+EXPIRY_SECONDS = 5 * 60
+
+
+def cached(timeout=EXPIRY_SECONDS, key='view/%s'):
+    """
+    A decorator for caching views.
+
+    Source: http://flask.pocoo.org/docs/patterns/viewdecorators/
+
+    With a little additional work it could be made into a generic caching
+    decorator for other functions that return pickleable data.
+    """
+    def decorator(f):
+        @wraps(f)
+        def decorated_function(*args, **kwargs):
+            cache_key = key % request.path
+            rv = cache.get(cache_key)
+            if rv is not None:
+                return rv
+            rv = f(*args, **kwargs)
+            cache.set(cache_key, rv, timeout=timeout)
+            return rv
+        return decorated_function
+    return decorator
+
+
+def activate_requests_caching():
+    """
+    Call once to activate caching for all HTTP GET issued by 'requests'
+    """
+    import requests_cache
+    requests_cache.install_cache(expire_after=EXPIRY_SECONDS)

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -7,3 +7,4 @@ zope.interface       # define and enforce interfaces
 certifi              # Module for Mozilla's CA bundle
 apitopy              # Required to implement the sprint.ly client
 jira-python>=0.13    # Required to access JIRA api
+requests-cache       # A transparent caching library for 'requests'


### PR DESCRIPTION
I have added some caching to HTTP client calls (that use requests, by introducing requests-cache https://requests-cache.readthedocs.org/) and to views.

This is not really the goal of #72 (which is mostly about speeding up user feedback by progressive render) but is going to be quite useful in an active multi-user environment.
