### PR TITLE
Allow more fine grained selection of projects and sorting

### DIFF
--- a/config/local_settings_carles_rbx.py
+++ b/config/local_settings_carles_rbx.py
@@ -3,9 +3,9 @@ from sprintly_auth import TOKEN
 GITHUB_CONFIG = {
     'organization': 'rockabox',
     'repositories': [
+        ('rockabox', 'youtube-frames-v2'),
         ('rockabox', 'rbx_web'),
         ('rockabox', 'conf'),
-        ('rockabox', 'youtube-frames'),
     ],
 }
 
@@ -16,6 +16,7 @@ SPRINTLY_CONFIG = {
         {'status': 'in-progress', 'limit': 100},
         {'status': 'backlog', 'limit': 100},
     ],
+    'products': [11356, 9134,]
 }
 
 GIT_CONFIG = {

--- a/deploystream/providers/sprintly/__init__.py
+++ b/deploystream/providers/sprintly/__init__.py
@@ -37,7 +37,7 @@ class SprintlyProvider(object):
     name = 'sprintly'
     oauth_token_name = None
 
-    def __init__(self, user, token, current, **kwargs):
+    def __init__(self, user, token, current, products=None, **kwargs):
         """
         Initialise by providing credentials and project IDs.
 
@@ -45,7 +45,10 @@ class SprintlyProvider(object):
         """
         self.api = Api('https://sprint.ly/api/',
                        (user, token), verify_ssl_cert=False, suffix='.json')
-        self.projects = self.api.products()
+        if products:
+            self.projects = products
+        else:
+            self.projects = [p.id for p in self.api.products()]
         self.current = current
 
     def get_features(self, **filters):
@@ -54,8 +57,8 @@ class SprintlyProvider(object):
         """
         features = []
 
-        for project in self.projects:
-            feature_endpoint = self.api.products[project.id].items
+        for project_id in self.projects:
+            feature_endpoint = self.api.products[project_id].items
             for criterion in self.current:
                 features += feature_endpoint(**criterion)
 


### PR DESCRIPTION
Work on #75 

Done:
- Added possibility to filter subsets of projects in sprintly and github, and choose display order in feature list

Pending:
- Tests
- Maybe rethink the sorting criteria in feature list: currently they are sorted by provider, and within provider there is some implicit sorting. It may be that I want to list first PRs and stories from given repos (intertwined providers) or by priority within repos... I may create a proper story for this
