### PR TITLE
Fix error in Oauth user creation return value

### DIFF
--- a/deploystream/apps/oauth/views.py
+++ b/deploystream/apps/oauth/views.py
@@ -76,8 +76,9 @@ def oauth_authorized(resp):
     remote_user = OAUTH_OBJECTS[oauth_name].get('/user')
     remote_user_id = remote_user.data['id']
 
-    user = get_or_create_user_oauth(current_user_id, remote_user_id,
-                        oauth_name, remote_user.data['login'])
+    user = get_or_create_user_oauth(
+        current_user_id, remote_user_id, oauth_name, remote_user.data['login']
+    )
 
     load_user_to_session(session, user)
 
@@ -122,8 +123,10 @@ def get_or_create_user_oauth(user_id, service_user_id, service_name,
             db.session.add(oauth)
             db.session.commit()
             user_id = current_user.id
+            user = current_user
         else:
             user_id = oauth_obj.user.id
+            user = oauth_obj.user
 
     else:
         # We're linking the account
@@ -133,8 +136,9 @@ def get_or_create_user_oauth(user_id, service_user_id, service_name,
                           user_id=user_id)
         db.session.add(oauth)
         db.session.commit()
+        user = oauth.user
 
-    return user_id
+    return user
 
 
 @app.route('/oauth/<oauth_name>')

--- a/deploystream/decorators.py
+++ b/deploystream/decorators.py
@@ -20,8 +20,10 @@ def needs_providers(func):
         try:
             providers = get_providers(config, session)
             return func(providers=providers, *args, **kwargs)
-        except MissingTokenException, te:
+        except MissingTokenException as te:
             # If we haven't got a required token, let's stop here and
             # go and get it.
+            # Unfortunately our API client calls are not currently dealing with
+            # OAUTH redirects at this point, so we may need to rework this...
             return oauth.views.start_token_processing(te.missing_token)
     return _wrapped


### PR DESCRIPTION
I just found this bug in a situation where I could no longer "login via github". Additionally, I was getting a missing token exception when listing features.
- `get_or_create_user_oauth` was returning a user_id while the caller expected a user instance.

This would need a regression test, but I did not have time to write it.

An additional problem left is the fact that we now generate Oauth 302 redirects as a result of API calls, which are not handled by the frontend. I guess that with the new way of handling user accounts and tokens, Oauth redirects should not happen at the points where we are issuing API calls, only at the point of generating tokens when assimilating a github account.
